### PR TITLE
Fix raw Markdown being served on published site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,10 @@ plugins:
 relative_links:
   enabled: true
   collections: true
+
+defaults:
+  - scope:
+      path: ""
+      type: pages
+    values:
+      layout: default


### PR DESCRIPTION
## Summary

PR #462 マージ後、`https://copilot-jp.github.io/project-sprint/` のホームページは表示されるようになったが、深い階層のページ（例: `https://copilot-jp.github.io/project-sprint/CODE/v4/v4_3_ja/framework.md`）が **Jekyll で処理されず、生の Markdown ソースとしてブラウザに配信されてしまう** 問題を修正。

## Root cause

Jekyll はデフォルトでは **YAML front matter（`---\n---` の囲み）が付いた `.md` ファイルだけ**を処理対象にし、それ以外は素材ファイルとしてそのままコピーする。本リポジトリの本文 Markdown は front matter を持たないため、Jekyll が素通しして公開してしまっていた。ホームページだけ表示できていたのは `jekyll-readme-index` プラグインが README.md を index.html に変換する特例による。

## Fix

`_config.yml` に front matter defaults を追加して、全 page スコープに `layout: default` を適用。これで front matter 無しの `.md` ファイルも Jekyll が処理対象として認識し、`jekyll-theme-minimal` のレイアウトが適用される。

```yaml
defaults:
  - scope:
      path: ""
      type: pages
    values:
      layout: default
```

## なぜこのアプローチか

- **既存の MD ファイルを一切編集しない**: 編集者の体験を変えない（PR #462 で確認済みの方針）
- **hundreds の `.md` に front matter を付ける作業が不要**
- **設定 1 ブロック追加だけ** という最小変更

## 確認手順（マージ後）

1. しばらく（数分）待ってから `https://copilot-jp.github.io/project-sprint/CODE/v4/v4_3_ja/framework.md` にアクセス
2. テーマレイアウト（`jekyll-theme-minimal`）が適用された HTML として表示されることを確認
3. 他の深い階層ページ（`introduction.md`, `definitions.md`, CODE/v3/* 等）も同様に確認

## Test plan

- [ ] `framework.md` がスタイル適用された状態で表示される（生ソース表示にならない）
- [ ] ホームページからリンク辿って各ページに遷移、404 や生表示にならない
- [ ] 画像・リンクが正常に動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)