### PR TITLE
Fix navigation links in root README to use markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   <img src='CODE/v4/v4_3_ja/images/pjs_og.png' width=600>
 </p>
 
-<p align="center">
-    【⚖️ <a href="CODE/v4/v4_3_ja/framework.md">Framework</a> | 🌏 <a href="CODE/v4/v4_3_ja/definitions.md">Definitions</a> | 🚀 <a href="CODE/v4/v4_3_ja/introduction.md">Introduction</a> | 👪 <a href="practical-guide/CODEv4_based/README.md">Practical Guide</a> | 📚 <a href="https://github.com/copilot-jp/project-sprint/releases">Release Note</a>】
+<p align="center" markdown="1">
+    【⚖️ [Framework](CODE/v4/v4_3_ja/framework.md) | 🌏 [Definitions](CODE/v4/v4_3_ja/definitions.md) | 🚀 [Introduction](CODE/v4/v4_3_ja/introduction.md) | 👪 [Practical Guide](practical-guide/CODEv4_based/README.md) | 📚 [Release Note](https://github.com/copilot-jp/project-sprint/releases)】
 
 </p>
 


### PR DESCRIPTION
## Summary

PR #463 で深い階層も Jekyll で処理されるようになり、`framework.html` 等の HTML 出力は実際に存在する状態になった。にもかかわらずホームページから飛ぶと **生 Markdown が表示される** 問題が残っていた。

レンダリング結果を確認したところ、原因は **`jekyll-relative-links` プラグインがマークダウン形式のリンク `[text](url.md)` は書き換えるものの、HTML の `<a href="...md">` タグは書き換えない**仕様であること。

ホームページのナビゲーション行（Framework / Definitions / Introduction / Practical Guide / Release Note）が HTML の `<a>` タグで書かれていたため、生 .md にリンクされていた。

## Fix

ルート [README.md](README.md) のナビゲーション行を：
- `<a href="x.md">y</a>` → `[y](x.md)`（マークダウンリンク）
- 中央寄せ用の `<p align="center">` には `markdown="1"` 属性を追加（kramdown が HTML ブロック内のマークダウンを解析できるように）

これにより：
- `jekyll-relative-links` が `.md` → 正しい URL に書き換える
- 中央寄せの見た目は維持される
- リポジトリ全体で残っていた最後の HTML `<a>` `.md` 参照箇所もこれで解消（`git grep` で確認済み）

## 確認手順（マージ後）

1. 数分待って `https://copilot-jp.github.io/project-sprint/` を再読み込み
2. ナビゲーション「Framework / Definitions / Introduction / Practical Guide」のいずれかをクリック
3. テーマ適用された HTML として表示される（生 Markdown ではない）
4. URL が `.md` ではなく `.html` または末尾スラッシュの形式に書き換わっている

## Test plan

- [ ] ホームのナビ「Framework」をクリック → スタイル適用された framework ページが表示
- [ ] 同様に Definitions / Introduction / Practical Guide でも生表示にならない
- [ ] GitHub web UI で README を見たときも、ナビゲーションが見た目崩れず表示される（中央寄せ + リンク動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)